### PR TITLE
docs: config.hの説明をREADME.mdに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,25 @@ pio run -t upload
 
 `src/config.h` で以下の設定が可能です:
 
-- フォント: `FONTNAME`
-- シリアルポート: `MODULE_LLM_UART_RX`, `MODULE_LLM_UART_TX`
-- LLMモデル: `MODEL`
+### フォント設定
+- `FONTNAME`: 日本語表示に対応したLGFXJapanGothicフォントを使用(デフォルト: fonts::lgfxJapanGothic_24)
+
+### 通信設定
+- `MODULE_LLM_UART_RX`: UART受信ピン(デフォルト: 2)
+- `MODULE_LLM_UART_TX`: UART送信ピン(デフォルト: 1)
+- M5Cardputerの Serial2 を使用してM5Module-LLMと通信
+
+### サウンド設定
+- `SOUND_VOLUME`: スピーカーの音量(0-255の範囲、0: 無音, 255: 最大音量)
+  デフォルト: 100
+
+### LLMモデル設定
+- `MODEL`: 使用するLLMモデルを指定(デフォルト: NULL)
+  - NULL: デフォルトモデルを使用
+  - 利用可能なモデル:
+    - qwen2.5-0.5B-prefill-20e: 小規模な高速モデル
+    - qwen2.5-1.5b-ax630c: 中規模な汎用モデル
+    - deepseek-r1-1.5B-ax630c: DeepSeekベースの高性能モデル
 
 ## ライセンス
 


### PR DESCRIPTION
## 変更内容

- config.hの設定項目の説明をREADME.mdに追記
- 設定項目を4つのカテゴリに分類(フォント、通信、サウンド、LLMモデル)
- 各設定のデフォルト値と詳細な説明を追加